### PR TITLE
[ADD] Aggiunta riferimento alle issues

### DIFF
--- a/sviluppo/review.rst
+++ b/sviluppo/review.rst
@@ -36,6 +36,7 @@ Revisione
 =========
 
 Prima di tutto è necessario capire cosa vuole ottenere chi ha creato la PR, quindi leggi la descrizione.
+Se alla PR è collegata una issue (cosa comunissima) leggi anche la descrizione e i commenti della issue, in quanto probabilmente troverai sia istruzioni per riprodurre il problema, sia commenti e spiegazioni sul perché di certe scelte di implementazione, che poi ritroverai nella PR stessa.
 Se ci sono aspetti non chiari, è possibile chiedere allo sviluppatore che ha implementato le modifiche aggiungendo un commento alla PR.
 
 .. image:: ./immagini/github_pr_comment.png


### PR DESCRIPTION
Credo che visto che rendiamo quasi obbligatorio per un PR avere una issue collegata, è bene spiegare che prima di far review potrebbe essere il caso di leggere la issue e i suoi commenti.